### PR TITLE
Fix test failures.

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -601,13 +601,12 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 	}
 
 	if p.PassRolesHeader {
-		type RoleProvider interface {
-			GetUserRoles() string
+		switch rp := p.provider.(type) {
+		case providers.RoleProvider:
+			roles := rp.GetUserRoles()
+			log.Printf("User role data - %v", roles)
+			req.Header["X-Forwarded-Roles"] = []string{roles}
 		}
-		rp := p.provider.(RoleProvider);
-		rp.GetUserRoles();
-		log.Printf("User role data - %v", rp.GetUserRoles())
-		req.Header["X-Forwarded-Roles"] = []string{rp.GetUserRoles()}
 	}
 
 	if session.Email == "" {

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -601,12 +601,10 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 	}
 
 	if p.PassRolesHeader {
-		switch rp := p.provider.(type) {
-		case providers.RoleProvider:
-			roles := rp.GetUserRoles()
-			log.Printf("User role data - %v", roles)
-			req.Header["X-Forwarded-Roles"] = []string{roles}
-		}
+		rp := p.provider.(providers.RoleProvider)
+		roles := rp.GetUserRoles()
+		log.Printf("User role data - %v", roles)
+		req.Header["X-Forwarded-Roles"] = []string{roles}
 	}
 
 	if session.Email == "" {

--- a/options.go
+++ b/options.go
@@ -179,9 +179,7 @@ func (o *Options) Validate() error {
 
 	// Confirm the provider type supports sending user roles
 	if o.PassRolesHeader {
-		if rp, ok := o.provider.(providers.RoleProvider); ok {
-			rp.GetUserRoles()
-		} else {
+		if _, ok := o.provider.(providers.RoleProvider); !ok {
 			msgs = append(msgs, "Provider '"+o.provider.Data().ProviderName+"' does not support sending a roles header.")
 		}
 	}

--- a/options.go
+++ b/options.go
@@ -94,7 +94,7 @@ func NewOptions() *Options {
 		PassBasicAuth:       true,
 		PassAccessToken:     false,
 		PassHostHeader:      true,
-		PassRolesHeader:     true,
+		PassRolesHeader:     false,
 		ApprovalPrompt:      "force",
 		RequestLogging:      true,
 	}
@@ -177,19 +177,14 @@ func (o *Options) Validate() error {
 			o.CookieExpire.String()))
 	}
 
-	// Todo - Read up on Go syntax and clean this up
 	// Confirm the provider type supports sending user roles
 	if o.PassRolesHeader {
-		type RoleProvider interface {
-			GetUserRoles() string
-		}
-		if rp, ok := o.provider.(RoleProvider); ok{
-			rp.GetUserRoles();
+		if rp, ok := o.provider.(providers.RoleProvider); ok {
+			rp.GetUserRoles()
 		} else {
-			msgs = append(msgs, "Provider '" + o.provider.Data().ProviderName + "' does not support sending a roles header.")
+			msgs = append(msgs, "Provider '"+o.provider.Data().ProviderName+"' does not support sending a roles header.")
 		}
 	}
-
 
 	if len(o.GoogleGroups) > 0 || o.GoogleAdminEmail != "" || o.GoogleServiceAccountJSON != "" {
 		if len(o.GoogleGroups) < 1 {

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -4,6 +4,8 @@ import (
 	"github.com/bitly/oauth2_proxy/cookie"
 )
 
+// Provider is the primary interface for an authentication provider
+// all provider
 type Provider interface {
 	Data() *ProviderData
 	GetEmailAddress(*SessionState) (string, error)
@@ -16,6 +18,14 @@ type Provider interface {
 	CookieForSession(*SessionState, *cookie.Cipher) (string, error)
 }
 
+// RoleProvider is an optional interface that exposes a list of roles
+// for a user. For Providers like GitHub this would be the teams the user
+// is a member of.
+type RoleProvider interface {
+	GetUserRoles() string
+}
+
+// New gives you an instance of the given provider
 func New(provider string, p *ProviderData) Provider {
 	switch provider {
 	case "myusa":


### PR DESCRIPTION
This cleans up the optional RoleProvider interface and fixes
some test crashes where PassRolesHeader was defaulting to true in
the test suite. Also fixes some lint.
