### PR TITLE
Fix only being able to log in once when validating team membership

### DIFF
--- a/providers/bitbucket.go
+++ b/providers/bitbucket.go
@@ -84,10 +84,11 @@ func (p *BitbucketProvider) GetEmailAddress(s *SessionState) (string, error) {
 
 	if p.Team != "" {
 		log.Printf("Filtering against membership in team %s\n", p.Team)
-		teamURL := p.ValidateURL
+		teamURL := &url.URL{}
+		*teamURL = *p.ValidateURL
 		teamURL.Path = "/2.0/teams"
 		req, err = http.NewRequest("GET",
-			p.ValidateURL.String()+"?role=member&access_token="+s.AccessToken, nil)
+			teamURL.String()+"?role=member&access_token="+s.AccessToken, nil)
 		if err != nil {
 			log.Printf("failed building request %s", err)
 			return "", err


### PR DESCRIPTION
It looks like `ValidateUrl` was aliased and then mutated, which caused the request to `ValidateUrl` to fail on the second attempt to log in, since it was actually fetching team membership.

Ideally there would also be a way to not have to rebuild this URL every validation, but that can happen later if desired.